### PR TITLE
fix indexer about nft burn / fix querier

### DIFF
--- a/submodules/move-nft/collect.go
+++ b/submodules/move-nft/collect.go
@@ -287,17 +287,12 @@ func (sm MoveNftSubmodule) handleBurnEvent(ctx context.Context, event types.Even
 	ownerAddr, _ := getVMAddress(cdc, token.OwnerAddr)
 	ownerSdkAddr := getCosmosAddress(ownerAddr)
 
-	err = sm.tokenOwnerMap.Remove(ctx, collections.Join3(ownerSdkAddr, tpk.K1(), tpk.K2()))
-	if err != nil {
-		sm.Logger(ctx).Error("failed to remove from tokenOwnerMap", "error", err)
-	}
-
 	err = sm.applyCollectionOwnerMap(ctx, collectionSdkAddr, ownerSdkAddr, false)
 	if err != nil {
 		return err // just return err, no wrap
 	}
 
-	err = sm.tokenOwnerMap.Set(ctx, collections.Join3(ownerSdkAddr, tpk.K1(), tpk.K2()), true)
+	err = sm.tokenOwnerMap.Remove(ctx, collections.Join3(ownerSdkAddr, tpk.K1(), tpk.K2()))
 	if err != nil {
 		sm.Logger(ctx).Error("failed to remove from tokenOwnerSet", "owner", ownerSdkAddr, "collection-addr", tpk.K1(), "token-id", tpk.K2(), "error", err)
 		return errors.New("failed to insert token into tokenOwnerSet")

--- a/submodules/move-nft/collect.go
+++ b/submodules/move-nft/collect.go
@@ -287,6 +287,11 @@ func (sm MoveNftSubmodule) handleBurnEvent(ctx context.Context, event types.Even
 	ownerAddr, _ := getVMAddress(cdc, token.OwnerAddr)
 	ownerSdkAddr := getCosmosAddress(ownerAddr)
 
+	err = sm.tokenOwnerMap.Remove(ctx, collections.Join3(ownerSdkAddr, tpk.K1(), tpk.K2()))
+	if err != nil {
+		sm.Logger(ctx).Error("failed to remove from tokenOwnerMap", "error", err)
+	}
+
 	err = sm.applyCollectionOwnerMap(ctx, collectionSdkAddr, ownerSdkAddr, false)
 	if err != nil {
 		return err // just return err, no wrap

--- a/submodules/move-nft/grpc_query.go
+++ b/submodules/move-nft/grpc_query.go
@@ -85,7 +85,8 @@ func (q Querier) CollectionsByAccount(ctx context.Context, req *nfttypes.QueryCo
 	for _, collectionSdkAddr := range collectionSdkAddrs {
 		collection, err := q.collectionMap.Get(ctx, collectionSdkAddr)
 		if err != nil {
-			return nil, handleCollectionErr(err)
+			q.Logger(ctx).Warn("index mismatch found", "collection", collectionSdkAddr, "action", "CollectionsByAccount")
+			continue
 		}
 		collection.Collection.Name, _ = q.getCollectionNameFromPairSubmodule(ctx, collection.Collection.Name)
 		collections = append(collections, &collection)
@@ -201,7 +202,8 @@ func (sm MoveNftSubmodule) getTokensByAccount(ctx context.Context, req *nfttypes
 	for _, identifier := range identifiers {
 		token, err := sm.tokenMap.Get(ctx, identifier)
 		if err != nil {
-			return nil, handleCollectionErr(err)
+			sm.Logger(ctx).Warn("index mismatch found", "account", ownerSdkAddr, "action", "CollectionsByAccount")
+			continue
 		}
 		token.CollectionName, _ = sm.getCollectionNameFromPairSubmodule(ctx, token.CollectionName)
 		res = append(res, &token)
@@ -241,7 +243,8 @@ func (sm MoveNftSubmodule) getTokensByAccountAndCollection(ctx context.Context, 
 	for _, identifier := range identifiers {
 		token, err := sm.tokenMap.Get(ctx, identifier)
 		if err != nil {
-			return nil, handleCollectionErr(err)
+			sm.Logger(ctx).Warn("index mismatch found", "account", ownerSdkAddr, "collection", colSdkAddr, "action", "GetTokensByAccountAndCollection")
+			continue
 		}
 		token.CollectionName, _ = sm.getCollectionNameFromPairSubmodule(ctx, token.CollectionName)
 		res = append(res, &token)

--- a/submodules/move-nft/submodule.go
+++ b/submodules/move-nft/submodule.go
@@ -31,10 +31,14 @@ type MoveNftSubmodule struct {
 	vmKeeper      types.MoveKeeper
 	pairSubmodule types.PairSubmodule
 
-	collectionMap      *collections.Map[sdk.AccAddress, nfttypes.IndexedCollection]
+	// collectionMap: key(collection address`), value(collection)
+	collectionMap *collections.Map[sdk.AccAddress, nfttypes.IndexedCollection]
+	// collectionOwnerMap: key(owner address, collection address), value(collection`s object address)
 	collectionOwnerMap *collections.Map[collections.Pair[sdk.AccAddress, sdk.AccAddress], uint64]
-	tokenMap           *collections.IndexedMap[collections.Pair[sdk.AccAddress, string], nfttypes.IndexedToken, TokenIndex]
-	tokenOwnerMap      *collections.Map[collections.Triple[sdk.AccAddress, sdk.AccAddress, string], bool]
+	// tokenMap: key(owner address, token id), value(token)
+	tokenMap *collections.IndexedMap[collections.Pair[sdk.AccAddress, string], nfttypes.IndexedToken, TokenIndex]
+	// tokenOwnerMap: key(owner address, collection address, token id), value(bool as placeholder)
+	tokenOwnerMap *collections.Map[collections.Triple[sdk.AccAddress, sdk.AccAddress, string], bool]
 }
 
 func NewMoveNftSubmodule(

--- a/submodules/move-nft/types/keys.go
+++ b/submodules/move-nft/types/keys.go
@@ -5,7 +5,7 @@ const (
 	SubmoduleName = "move-nft"
 
 	// Version is the current version of the submodule
-	Version = "v0.1.2"
+	Version = "v0.1.3"
 )
 
 // store prefixes

--- a/submodules/wasm-nft/collect.go
+++ b/submodules/wasm-nft/collect.go
@@ -174,7 +174,7 @@ func (sm WasmNFTSubmodule) handleBurnEvent(ctx context.Context, event types.Even
 	ownerAddr, _ := getVMAddress(sm.ac, token.OwnerAddr)
 	ownerSdkAddr := getCosmosAddress(ownerAddr)
 
-	err = sm.tokenOwnerMap.Set(ctx, collections.Join3(ownerSdkAddr, tpk.K1(), tpk.K2()), true)
+	err = sm.tokenOwnerMap.Remove(ctx, collections.Join3(ownerSdkAddr, tpk.K1(), tpk.K2()))
 	if err != nil {
 		sm.Logger(ctx).Error("failed to remove from tokenOwnerSet", "owner", ownerSdkAddr, "collection-addr", tpk.K1(), "token-id", tpk.K2(), "error", err)
 		return cosmoserr.Wrap(err, "failed to insert token into tokenOwnerSet")

--- a/submodules/wasm-nft/grpc_query.go
+++ b/submodules/wasm-nft/grpc_query.go
@@ -85,7 +85,8 @@ func (q Querier) CollectionsByAccount(ctx context.Context, req *nfttypes.QueryCo
 	for _, collectionSdkAddr := range collectionSdkAddrs {
 		collection, err := q.collectionMap.Get(ctx, collectionSdkAddr)
 		if err != nil {
-			return nil, handleCollectionErr(err)
+			q.Logger(ctx).Warn("index mismatch found", "collection", collectionSdkAddr, "action", "CollectionsByAccount")
+			continue
 		}
 		collection.Collection.Name, _ = q.getCollectionNameFromPairSubmodule(ctx, collection.Collection.Name)
 		collections = append(collections, &collection)
@@ -203,7 +204,8 @@ func (sm WasmNFTSubmodule) getTokensByAccount(ctx context.Context, req *nfttypes
 	for _, identifier := range identifiers {
 		token, err := sm.tokenMap.Get(ctx, identifier)
 		if err != nil {
-			return nil, handleCollectionErr(err)
+			sm.Logger(ctx).Warn("index mismatch found", "account", ownerSdkAddr, "action", "CollectionsByAccount")
+			continue
 		}
 		token.CollectionName, _ = sm.getCollectionNameFromPairSubmodule(ctx, token.CollectionName)
 		res = append(res, &token)

--- a/submodules/wasm-nft/grpc_query.go
+++ b/submodules/wasm-nft/grpc_query.go
@@ -229,24 +229,29 @@ func (sm WasmNFTSubmodule) getTokensByAccountAndCollection(ctx context.Context, 
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	ownerSdkAddr := getCosmosAddress(ownerAddr)
-	ownerAddrStr := ownerSdkAddr.String()
 
-	res, pageRes, err := query.CollectionFilteredPaginate(ctx, sm.tokenMap, req.Pagination,
-		func(k collections.Pair[sdk.AccAddress, string], v nfttypes.IndexedToken) (bool, error) {
-			if slices.Equal(k.K1(), colSdkAddr) && (v.OwnerAddr == ownerAddrStr) {
-				return true, nil
-			}
-			return false, nil
+	identifiers := []collections.Pair[sdk.AccAddress, string]{}
+	_, pageRes, err := query.CollectionPaginate(ctx, sm.tokenOwnerMap, req.Pagination,
+		func(k collections.Triple[sdk.AccAddress, sdk.AccAddress, string], v bool) (bool, error) {
+			identifiers = append(identifiers, collections.Join(k.K2(), k.K3()))
+			return v, nil
 		},
-		func(k collections.Pair[sdk.AccAddress, string], v nfttypes.IndexedToken) (*nfttypes.IndexedToken, error) {
-			v.CollectionName, _ = sm.getCollectionNameFromPairSubmodule(ctx, v.CollectionName)
-			return &v, nil
-		},
+		WithCollectionPaginationTriplePrefix2[sdk.AccAddress, sdk.AccAddress, string](ownerSdkAddr, colSdkAddr),
 	)
-
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, handleCollectionErr(err)
 	}
+	res := []*nfttypes.IndexedToken{}
+	for _, identifier := range identifiers {
+		token, err := sm.tokenMap.Get(ctx, identifier)
+		if err != nil {
+			sm.Logger(ctx).Warn("index mismatch found", "account", ownerSdkAddr, "collection", colSdkAddr, "action", "GetTokensByAccountAndCollection")
+			continue
+		}
+		token.CollectionName, _ = sm.getCollectionNameFromPairSubmodule(ctx, token.CollectionName)
+		res = append(res, &token)
+	}
+
 	res = slices.DeleteFunc(res, func(item *nfttypes.IndexedToken) bool {
 		return item == nil
 	})
@@ -287,6 +292,13 @@ func (sm WasmNFTSubmodule) getTokensByAccountCollectionAndTokenId(ctx context.Co
 func WithCollectionPaginationTriplePrefix[K1, K2, K3 any](prefix K1) func(o *query.CollectionsPaginateOptions[collections.Triple[K1, K2, K3]]) {
 	return func(o *query.CollectionsPaginateOptions[collections.Triple[K1, K2, K3]]) {
 		prefix := collections.TriplePrefix[K1, K2, K3](prefix)
+		o.Prefix = &prefix
+	}
+}
+
+func WithCollectionPaginationTriplePrefix2[K1, K2, K3 any](prefix K1, prefix2 K2) func(o *query.CollectionsPaginateOptions[collections.Triple[K1, K2, K3]]) {
+	return func(o *query.CollectionsPaginateOptions[collections.Triple[K1, K2, K3]]) {
+		prefix := collections.TripleSuperPrefix[K1, K2, K3](prefix, prefix2)
 		o.Prefix = &prefix
 	}
 }

--- a/submodules/wasm-nft/submodule.go
+++ b/submodules/wasm-nft/submodule.go
@@ -31,10 +31,14 @@ type WasmNFTSubmodule struct {
 	vmKeeper      types.WasmKeeper
 	pairSubmodule types.PairSubmodule
 
-	collectionMap      *collections.Map[sdk.AccAddress, nfttypes.IndexedCollection]
+	// collectionMap: key(collection address`), value(collection)
+	collectionMap *collections.Map[sdk.AccAddress, nfttypes.IndexedCollection]
+	// collectionOwnerMap: key(owner address, collection address), value(collection`s object address)
 	collectionOwnerMap *collections.Map[collections.Pair[sdk.AccAddress, sdk.AccAddress], uint64]
-	tokenMap           *collections.Map[collections.Pair[sdk.AccAddress, string], nfttypes.IndexedToken]
-	tokenOwnerMap      *collections.Map[collections.Triple[sdk.AccAddress, sdk.AccAddress, string], bool]
+	// tokenMap: key(owner address, token id), value(token)
+	tokenMap *collections.Map[collections.Pair[sdk.AccAddress, string], nfttypes.IndexedToken]
+	// tokenOwnerMap: key(owner address, collection address, token id), value(bool as placeholder)
+	tokenOwnerMap *collections.Map[collections.Triple[sdk.AccAddress, sdk.AccAddress, string], bool]
 }
 
 func NewWasmNFTSubmodule(

--- a/submodules/wasm-nft/types/keys.go
+++ b/submodules/wasm-nft/types/keys.go
@@ -5,7 +5,7 @@ const (
 	SubmoduleName = "wasm-nft"
 
 	// Version is the current version of the submodule
-	Version = "v0.1.2"
+	Version = "v0.1.3"
 )
 
 // store prefixes


### PR DESCRIPTION
fix move-nft and wasm-nft
* remove item from TokenOwnerMap for burnt nfts
* in query, ignore invalid item instead of returning error