### PR TITLE
decrease cache size

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,7 +59,7 @@ func (c IndexerConfig) IsEnabled() bool {
 func DefaultConfig() IndexerConfig {
 	return IndexerConfig{
 		Enable:        true,
-		CacheSize:     1_000_000,
+		CacheSize:     100_000,
 		BackendConfig: store.DefaultConfig(),
 	}
 }


### PR DESCRIPTION
1M cache is too big for many operators - it may consume 10G of RAM because of huge blocks
so decreasing to 100k sounds more reasonable