### PR TITLE
fix: don't abort on nft index failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## [Unreleased]
 
 * (cache) Change cache-capacity unit to MiB
+* (submodule/move-nft, submodule/wasm-nft) fix: don't abort on nft index failure
 
 ## [v0.1.5](https://github.com/initia-labs/kvindexer/releases/tag/v0.1.5) - 2024-07-16
 

--- a/submodules/move-nft/collect.go
+++ b/submodules/move-nft/collect.go
@@ -47,7 +47,7 @@ func (sm MoveNftSubmodule) processEvents(ctx context.Context, events []types.Eve
 		}
 		if err := fn(ctx, event); err != nil {
 			sm.Logger(ctx).Error("failed to handle nft-related event", "error", err.Error())
-			return cosmoserr.Wrap(err, "failed to handle nft-related event")
+			// don't return here because we want to process all events
 		}
 	}
 	return nil

--- a/submodules/wasm-nft/collect.go
+++ b/submodules/wasm-nft/collect.go
@@ -45,7 +45,7 @@ func (sm WasmNFTSubmodule) processEvents(ctx context.Context, events []types.Eve
 
 		if err := fn(ctx, event); err != nil {
 			sm.Logger(ctx).Error("failed to handle nft-related event", "error", err.Error())
-			return cosmoserr.Wrap(err, "failed to handle nft-related event")
+			// don't return here because we want to process all events
 		}
 	}
 	return nil

--- a/submodules/wasm-nft/types/types.go
+++ b/submodules/wasm-nft/types/types.go
@@ -21,7 +21,7 @@ type CollectionResource struct {
 // internal use only: struct from move resource
 type NftResource struct {
 	TokenUri  string      `json:"token_uri"`
-	Extention interface{} `json:"extension"`
+	Extension interface{} `json:"extension"`
 }
 
 type ContractInfo struct {


### PR DESCRIPTION
It seems that some events are not being indexed properly by previous events.