### PR TITLE
collect addresses fromt transfer topic

### DIFF
--- a/submodules/evm-tx/types/keys.go
+++ b/submodules/evm-tx/types/keys.go
@@ -5,7 +5,7 @@ const (
 	SubmoduleName = "evm-tx"
 
 	// Version is the current version of the submodule
-	Version = "v0.1.0"
+	Version = "v0.1.1"
 )
 
 // store prefixes


### PR DESCRIPTION
If the topic is about transfer, we need to extract the addresses from the topics.
* Topics[1] is the sender, Topics[2] is the receiver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced address extraction from Ethereum logs to support multiple contract addresses.
	- Improved functionality for identifying and extracting sender and receiver addresses during token transfers.

- **Bug Fixes**
	- Updated logic in the address extraction process to ensure accurate handling of transfer events.

- **Chores**
	- Minor version update of the `evm-tx` submodule to reflect recent improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->