### PR TITLE
Feat/prune

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,8 +13,8 @@ import (
 const (
 	flagIndexerEnable        = "indexer.enable"
 	flagIndexerCacheCapacity = "indexer.cache-capacity"
-	flagIndexerBackend       = "indexer.backend"
 	flagIndexerRetainHeight  = "indexer.retain-height"
+	flagIndexerBackend       = "indexer.backend"
 )
 
 func NewConfig(appOpts servertypes.AppOptions) (*IndexerConfig, error) {
@@ -27,13 +27,13 @@ func NewConfig(appOpts servertypes.AppOptions) (*IndexerConfig, error) {
 
 	cfg.CacheCapacity = cast.ToInt(appOpts.Get(flagIndexerCacheCapacity))
 
+	cfg.RetainHeight = cast.ToUint64(appOpts.Get(flagIndexerRetainHeight))
+
 	cfg.BackendConfig = viper.New()
 	err := cfg.BackendConfig.MergeConfigMap(cast.ToStringMap(appOpts.Get(flagIndexerBackend)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to merge backend config: %w", err)
 	}
-
-	cfg.RetainHeight = cast.ToUint64(appOpts.Get(flagIndexerRetainHeight))
 
 	return cfg, nil
 }
@@ -62,7 +62,7 @@ func DefaultConfig() IndexerConfig {
 	return IndexerConfig{
 		Enable:        true,
 		CacheCapacity: 500, // 500 MiB
-		BackendConfig: store.DefaultConfig(),
 		RetainHeight:  0,
+		BackendConfig: store.DefaultConfig(),
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ func NewConfig(appOpts servertypes.AppOptions) (*IndexerConfig, error) {
 
 	cfg.CacheCapacity = cast.ToInt(appOpts.Get(flagIndexerCacheCapacity))
 
-	cfg.RetainHeight = cast.ToUint64(appOpts.Get(flagIndexerRetainHeight))
+	cfg.RetainHeight = cast.ToInt64(appOpts.Get(flagIndexerRetainHeight))
 
 	cfg.BackendConfig = viper.New()
 	err := cfg.BackendConfig.MergeConfigMap(cast.ToStringMap(appOpts.Get(flagIndexerBackend)))
@@ -45,6 +45,10 @@ func (c IndexerConfig) Validate() error {
 
 	if c.CacheCapacity == 0 {
 		return fmt.Errorf("cache capacity must be greater than 0")
+	}
+
+	if c.RetainHeight < 0 {
+		return fmt.Errorf("retain height must be nonnegative")
 	}
 
 	if c.BackendConfig == nil {

--- a/config/config.go
+++ b/config/config.go
@@ -12,8 +12,9 @@ import (
 
 const (
 	flagIndexerEnable        = "indexer.enable"
-	flagIndexerBackend       = "indexer.backend"
 	flagIndexerCacheCapacity = "indexer.cache-capacity"
+	flagIndexerBackend       = "indexer.backend"
+	flagIndexerRetainHeight  = "indexer.retain-height"
 )
 
 func NewConfig(appOpts servertypes.AppOptions) (*IndexerConfig, error) {
@@ -23,6 +24,7 @@ func NewConfig(appOpts servertypes.AppOptions) (*IndexerConfig, error) {
 	if !cfg.Enable {
 		return cfg, nil
 	}
+
 	cfg.CacheCapacity = cast.ToInt(appOpts.Get(flagIndexerCacheCapacity))
 
 	cfg.BackendConfig = viper.New()
@@ -31,7 +33,7 @@ func NewConfig(appOpts servertypes.AppOptions) (*IndexerConfig, error) {
 		return nil, fmt.Errorf("failed to merge backend config: %w", err)
 	}
 
-	cfg.CacheCapacity = cast.ToInt(appOpts.Get(flagIndexerCacheCapacity))
+	cfg.RetainHeight = cast.ToUint64(appOpts.Get(flagIndexerRetainHeight))
 
 	return cfg, nil
 }
@@ -61,5 +63,6 @@ func DefaultConfig() IndexerConfig {
 		Enable:        true,
 		CacheCapacity: 500, // 500 MiB
 		BackendConfig: store.DefaultConfig(),
+		RetainHeight:  0,
 	}
 }

--- a/config/types.go
+++ b/config/types.go
@@ -10,14 +10,14 @@ type IndexerConfig struct {
 	Enable bool `mapstructure:"indexer.enable"`
 	// CacheCapacity defines the size of the cache used by the kvindexer. (unit: MiB)
 	CacheCapacity int `mapstructure:"indexer.cache-capacity"`
+	// RetainHeight is the height to retain indexer data.
+	// If 0, it will retain all data.
+	RetainHeight uint64 `mapstructure:"indexer.retain-height"`
 	// Backend defines the type of the backend store and its options.
 	//  It should have a key-value pair named 'type', and the value should exist in store supported by cosmos-db.
 	// Recommend to use default value unless you know about backend db storage.
 	// NOTE: "goleveldb" is the only supported type in the current version.
 	BackendConfig *viper.Viper `mapstructure:"indexer.backend"`
-	// RetainHeight is the height to retain indexer data.
-	// If 0, it will retain all data.
-	RetainHeight uint64 `mapstructure:"indexer.retain-height"`
 }
 
 const DefaultConfigTemplate = `
@@ -33,14 +33,14 @@ enable = {{ .IndexerConfig.Enable }}
 # CacheCapacity defines the size of the cache. (unit: MiB)
 cache-capacity = {{ .IndexerConfig.CacheCapacity }}
 
+# RetainHeight is the height to retain indexer data.
+# If 0, it will retain all data.
+retain-height = {{ .IndexerConfig.RetainHeight }}
+
 # Backend defines the type of the backend store and its options.
 # It should have a key-value pair named 'type', and the value should exist in store supported by cosmos-db.
 # Recommend to use default value unless you know about backend db storage.
 # supported type: "goleveldb" only in current
 [indexer.backend]
 {{ range $key, $value := .IndexerConfig.BackendConfig.AllSettings }}{{ printf "%s = \"%v\"\n" $key $value }}{{end}}
-
-# RetainHeight is the height to retain indexer data.
-# If 0, it will retain all data.
-retain-height = {{ .IndexerConfig.RetainHeight }}
 `

--- a/config/types.go
+++ b/config/types.go
@@ -15,6 +15,9 @@ type IndexerConfig struct {
 	// Recommend to use default value unless you know about backend db storage.
 	// NOTE: "goleveldb" is the only supported type in the current version.
 	BackendConfig *viper.Viper `mapstructure:"indexer.backend"`
+	// RetainHeight is the height to retain indexer data.
+	// If 0, it will retain all data.
+	RetainHeight uint64 `mapstructure:"indexer.retain-height"`
 }
 
 const DefaultConfigTemplate = `
@@ -36,4 +39,8 @@ cache-capacity = {{ .IndexerConfig.CacheCapacity }}
 # supported type: "goleveldb" only in current
 [indexer.backend]
 {{ range $key, $value := .IndexerConfig.BackendConfig.AllSettings }}{{ printf "%s = \"%v\"\n" $key $value }}{{end}}
+
+# RetainHeight is the height to retain indexer data.
+# If 0, it will retain all data.
+retain-height = {{ .IndexerConfig.RetainHeight }}
 `

--- a/config/types.go
+++ b/config/types.go
@@ -12,7 +12,7 @@ type IndexerConfig struct {
 	CacheCapacity int `mapstructure:"indexer.cache-capacity"`
 	// RetainHeight is the height to retain indexer data.
 	// If 0, it will retain all data.
-	RetainHeight uint64 `mapstructure:"indexer.retain-height"`
+	RetainHeight int64 `mapstructure:"indexer.retain-height"`
 	// Backend defines the type of the backend store and its options.
 	//  It should have a key-value pair named 'type', and the value should exist in store supported by cosmos-db.
 	// Recommend to use default value unless you know about backend db storage.

--- a/go.work.sum
+++ b/go.work.sum
@@ -51,6 +51,7 @@ cloud.google.com/go/apigateway v1.6.5/go.mod h1:6wCwvYRckRQogyDDltpANi3zsCDl6kWi
 cloud.google.com/go/apigeeconnect v1.6.5/go.mod h1:MEKm3AiT7s11PqTfKE3KZluZA9O91FNysvd3E6SJ6Ow=
 cloud.google.com/go/apigeeregistry v0.8.3/go.mod h1:aInOWnqF4yMQx8kTjDqHNXjZGh/mxeNlAf52YqtASUs=
 cloud.google.com/go/apikeys v0.5.0/go.mod h1:5aQfwY4D+ewMMWScd3hm2en3hCj+BROlyrt3ytS7KLI=
+cloud.google.com/go/apikeys v0.6.0/go.mod h1:kbpXu5upyiAlGkKrJgQl8A0rKNNJ7dQ377pdroRSSi8=
 cloud.google.com/go/appengine v1.8.5/go.mod h1:uHBgNoGLTS5di7BvU25NFDuKa82v0qQLjyMJLuPQrVo=
 cloud.google.com/go/area120 v0.5.0/go.mod h1:DE/n4mp+iqVyvxHN41Vf1CR602GiHQjFPusMFW6bGR4=
 cloud.google.com/go/area120 v0.6.0/go.mod h1:39yFJqWVgm0UZqWTOdqkLhjoC7uFfgXRC8g/ZegeAh0=
@@ -273,11 +274,14 @@ cloud.google.com/go/securitycenter v1.13.0/go.mod h1:cv5qNAqjY84FCN6Y9z28WlkKXyW
 cloud.google.com/go/securitycenter v1.14.0/go.mod h1:gZLAhtyKv85n52XYWt6RmeBdydyxfPeTrpToDPw4Auc=
 cloud.google.com/go/securitycenter v1.24.4/go.mod h1:PSccin+o1EMYKcFQzz9HMMnZ2r9+7jbc+LvPjXhpwcU=
 cloud.google.com/go/servicecontrol v1.10.0/go.mod h1:pQvyvSRh7YzUF2efw7H87V92mxU8FnFDawMClGCNuAA=
+cloud.google.com/go/servicecontrol v1.11.1/go.mod h1:aSnNNlwEFBY+PWGQ2DoM0JJ/QUXqV5/ZD9DOLB7SnUk=
 cloud.google.com/go/servicedirectory v1.4.0/go.mod h1:gH1MUaZCgtP7qQiI+F+A+OpeKF/HQWgtAddhTbhL2bs=
 cloud.google.com/go/servicedirectory v1.5.0/go.mod h1:QMKFL0NUySbpZJ1UZs3oFAmdvVxhhxB6eJ/Vlp73dfg=
 cloud.google.com/go/servicedirectory v1.11.4/go.mod h1:Bz2T9t+/Ehg6x+Y7Ycq5xiShYLD96NfEsWNHyitj1qM=
 cloud.google.com/go/servicemanagement v1.6.0/go.mod h1:aWns7EeeCOtGEX4OvZUWCCJONRZeFKiptqKf1D0l/Jc=
+cloud.google.com/go/servicemanagement v1.8.0/go.mod h1:MSS2TDlIEQD/fzsSGfCdJItQveu9NXnUniTrq/L8LK4=
 cloud.google.com/go/serviceusage v1.5.0/go.mod h1:w8U1JvqUqwJNPEOTQjrMHkw3IaIFLoLsPLvsE3xueec=
+cloud.google.com/go/serviceusage v1.6.0/go.mod h1:R5wwQcbOWsyuOfbP9tGdAnCAc6B9DRwPG1xtWMDeuPA=
 cloud.google.com/go/shell v1.7.5/go.mod h1:hL2++7F47/IfpfTO53KYf1EC+F56k3ThfNEXd4zcuiE=
 cloud.google.com/go/spanner v1.7.0/go.mod h1:sd3K2gZ9Fd0vMPLXzeCrF6fq4i63Q7aTLW/lBIfBkIk=
 cloud.google.com/go/spanner v1.56.0/go.mod h1:DndqtUKQAt3VLuV2Le+9Y3WTnq5cNKrnLb/Piqcj+h0=
@@ -344,6 +348,11 @@ cosmossdk.io/x/tx v0.13.0/go.mod h1:CpNQtmoqbXa33/DVxWQNx5Dcnbkv2xGUhL7tYQ5wUsY=
 cosmossdk.io/x/upgrade v0.1.0/go.mod h1:/6jjNGbiPCNtmA1N+rBtP601sr0g4ZXuj3yC6ClPCGY=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
+gioui.org v0.2.0/go.mod h1:1H72sKEk/fNFV+l0JNeM2Dt3co3Y4uaQcD+I+/GQ0e4=
+gioui.org/cpu v0.0.0-20220412190645-f1e9e8c3b1f7/go.mod h1:A8M0Cn5o+vY5LTMlnRoK3O5kG+rH0kWfJjeKd9QpBmQ=
+gioui.org/shader v1.0.6/go.mod h1:mWdiME581d/kV7/iEhLmUgUK5iZ09XR5XpduXzbePVM=
+gioui.org/x v0.2.0/go.mod h1:rCGN2nZ8ZHqrtseJoQxCMZpt2xrZUrdZ2WuMRLBJmYs=
+git.sr.ht/~sbinet/cmpimg v0.1.0/go.mod h1:FU12psLbF4TfNXkKH2ZZQ29crIqoiqTZmeQ7dkp/pxE=
 git.sr.ht/~sbinet/gg v0.3.1/go.mod h1:KGYtlADtqsqANL9ueOFkWymvzUvLMQllU5Ixo+8v3pc=
 git.sr.ht/~sbinet/gg v0.5.0/go.mod h1:G2C0eRESqlKhS7ErsNey6HHrqU1PwsnCQlekFi9Q2Oo=
 github.com/4meepo/tagalign v1.3.3/go.mod h1:Q9c1rYMZJc9dPRkbQPpcBNCLEmY2njbAsXhQOZFE2dE=
@@ -439,6 +448,7 @@ github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu
 github.com/andybalholm/brotli v1.0.3/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/andybalholm/stroke v0.0.0-20221221101821-bd29b49d73f0/go.mod h1:ccdDYaY5+gO+cbnQdFxEXqfy0RkoV25H3jLXUDNM3wg=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
@@ -657,6 +667,7 @@ github.com/docker/cli v23.0.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvM
 github.com/docker/cli v24.0.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v23.0.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.9+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
@@ -731,6 +742,7 @@ github.com/ghostiam/protogetter v0.3.3/go.mod h1:A0JgIhs0fgVnotGinjQiKaFVG3waItL
 github.com/ghostiam/protogetter v0.3.5/go.mod h1:7lpeDnEJ1ZjL/YtyoN99ljO4z0pd3H0d18/t2dPBxHw=
 github.com/ghostiam/protogetter v0.3.6/go.mod h1:7lpeDnEJ1ZjL/YtyoN99ljO4z0pd3H0d18/t2dPBxHw=
 github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=
+github.com/gliderlabs/ssh v0.3.7/go.mod h1:zpHEXBstFnQYtGnB8k8kQLol82umzn/2/snG7alWVD8=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-critic/go-critic v0.7.0/go.mod h1:moYzd7GdVXE2C2hYTwd7h0CPcqlUeclsyBRwMa38v64=
@@ -739,11 +751,14 @@ github.com/go-critic/go-critic v0.11.2/go.mod h1:OePaicfjsf+KPy33yq4gzv6CO7TEQ9R
 github.com/go-critic/go-critic v0.11.3/go.mod h1:Je0h5Obm1rR5hAGA9mP2PDiOOk53W+n7pyvXErFKIgI=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
+github.com/go-fonts/dejavu v0.3.2/go.mod h1:m+TzKY7ZEl09/a17t1593E4VYW8L1VaBXHzFZOIjGEY=
 github.com/go-fonts/latin-modern v0.2.0/go.mod h1:rQVLdDMK+mK1xscDwsqM5J8U2jrRa3T0ecnM9pNujks=
+github.com/go-fonts/latin-modern v0.3.2/go.mod h1:9odJt4NbRrbdj4UAMuLVd4zEukf6aAEKnDaQga0whqQ=
 github.com/go-fonts/liberation v0.1.1/go.mod h1:K6qoJYypsmfVjWg8KOVDQhLc8UDgIK2HYqyqAO9z7GY=
 github.com/go-fonts/liberation v0.2.0/go.mod h1:K6qoJYypsmfVjWg8KOVDQhLc8UDgIK2HYqyqAO9z7GY=
 github.com/go-fonts/liberation v0.3.2/go.mod h1:N0QsDLVUQPy3UYg9XAc3Uh3UDMp2Z7M1o4+X98dXkmI=
 github.com/go-fonts/stix v0.1.0/go.mod h1:w/c1f0ldAUlJmLBvlbkvVXLAD+tAMqobIIQpmnUIzUY=
+github.com/go-fonts/stix v0.2.2/go.mod h1:SUxggC9dxd/Q+rb5PkJuvfvTbOPtNc2Qaua00fIp9iU=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.5.0/go.mod h1:hmexnoNsr2SJU1Ju67OaNz5ASJY3+sHgFRpCtpDCKow=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
@@ -777,6 +792,7 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
+github.com/go-text/typesetting v0.0.0-20230803102845-24e03d8b5372/go.mod h1:evDBbvNR/KaVFZ2ZlDSOWWXIUKq0wCOEtzLxRM8SG3k=
 github.com/go-toolsmith/astcast v1.1.0/go.mod h1:qdcuFWeGGS2xX5bLM/c3U9lewg7+Zu4mr+xPwZIB4ZU=
 github.com/go-toolsmith/astcopy v1.0.2/go.mod h1:4TcEdbElGc9twQEYpVo/aieIXfHhiuLh4aLAck6dO7Y=
 github.com/go-toolsmith/astcopy v1.1.0/go.mod h1:hXM6gan18VA1T/daUEHCFcYiW8Ai1tIwIzHY6srfEAw=
@@ -1148,6 +1164,7 @@ github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/z
 github.com/lufeee/execinquery v1.2.1/go.mod h1:EC7DrEKView09ocscGHC+apXMIaorh4xqSxS/dy8SbM=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lyft/protoc-gen-star/v2 v2.0.3/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
+github.com/lyft/protoc-gen-star/v2 v2.0.4-0.20230330145011-496ad1ac90a4/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
 github.com/macabu/inamedparam v0.1.2/go.mod h1:Xg25QvY7IBRl1KLPV9Rbml8JOMZtF/iAkNkmV7eQgjw=
 github.com/macabu/inamedparam v0.1.3/go.mod h1:93FLICAIk/quk7eaPPQvbzihUdn/QkGDwIZEoLtpH6I=
 github.com/magefile/mage v1.14.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
@@ -1175,6 +1192,7 @@ github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-sqlite3 v1.14.5/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.9/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
@@ -1701,6 +1719,7 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQz
 golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
 golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/exp v0.0.0-20240314144324-c7f7c6466f7f/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
+golang.org/x/exp/shiny v0.0.0-20230801115018-d63ba01acd4b/go.mod h1:UH99kUObWAZkDnWqppdQe5ZhPYESUw8I0zVV1uWBR+0=
 golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=

--- a/submodules/block/prune.go
+++ b/submodules/block/prune.go
@@ -1,0 +1,12 @@
+package block
+
+import (
+	"context"
+
+	"cosmossdk.io/collections"
+)
+
+func (bs BlockSubmodule) prune(ctx context.Context, minHeight int64) error {
+	rn := new(collections.Range[int64]).StartInclusive(1).EndInclusive(minHeight)
+	return bs.blockByHeight.Clear(ctx, rn)
+}

--- a/submodules/block/submodule.go
+++ b/submodules/block/submodule.go
@@ -85,3 +85,7 @@ func (sub BlockSubmodule) FinalizeBlock(ctx context.Context, req abci.RequestFin
 func (sub BlockSubmodule) Commit(ctx context.Context, res abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
 	return nil
 }
+
+func (sub BlockSubmodule) Prune(ctx context.Context, minHeight int64) error {
+	return sub.prune(ctx, minHeight)
+}

--- a/submodules/block/types/keys.go
+++ b/submodules/block/types/keys.go
@@ -5,7 +5,7 @@ const (
 	SubmoduleName = "block"
 
 	// Version is the current version of the submodule
-	Version = "v0.1.0"
+	Version = "v0.1.1"
 )
 
 const (

--- a/submodules/evm-nft/submodule.go
+++ b/submodules/evm-nft/submodule.go
@@ -125,3 +125,7 @@ func (sub EvmNFTSubmodule) FinalizeBlock(ctx context.Context, req abci.RequestFi
 func (sub EvmNFTSubmodule) Commit(ctx context.Context, res abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
 	return nil
 }
+
+func (sub EvmNFTSubmodule) Prune(ctx context.Context, minHeight int64) error {
+	return nil
+}

--- a/submodules/evm-tx/go.mod
+++ b/submodules/evm-tx/go.mod
@@ -1,8 +1,6 @@
 module github.com/initia-labs/kvindexer/submodules/evm-tx
 
-go 1.22.7
-
-toolchain go1.23.3
+go 1.23.3
 
 require (
 	cosmossdk.io/collections v0.4.0

--- a/submodules/evm-tx/go.mod
+++ b/submodules/evm-tx/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/initia-labs/kvindexer v0.1.3
-	github.com/initia-labs/kvindexer/submodules/tx v0.1.0
 	github.com/initia-labs/minievm v0.3.1
 	google.golang.org/genproto/googleapis/api v0.0.0-20240814211410-ddb44dafa142
 	google.golang.org/grpc v1.67.1

--- a/submodules/evm-tx/go.sum
+++ b/submodules/evm-tx/go.sum
@@ -419,8 +419,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/initia-labs/kvindexer/submodules/tx v0.1.0 h1:6kbf6wmzXPN0XCQLasiFgq1AlZHkt5K3/ZG+IWw1nNs=
-github.com/initia-labs/kvindexer/submodules/tx v0.1.0/go.mod h1:i0XeLbLa6xdgTR01WF8kaAO50vMmwxbeq0fKexwpFHU=
 github.com/initia-labs/minievm v0.3.1 h1:XDYp0CWfDpx8/AHpqjT+sfnJF26IqMzc9RSEl+uXU7U=
 github.com/initia-labs/minievm v0.3.1/go.mod h1:4NKOOgvweeuqk6Hkt5yJ+rXX1mXnKwG6hfM9qCyVMZ8=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=

--- a/submodules/evm-tx/grpc_query.go
+++ b/submodules/evm-tx/grpc_query.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/initia-labs/kvindexer/submodules/tx/types"
+	"github.com/initia-labs/kvindexer/submodules/evm-tx/types"
 )
 
 var _ types.QueryServer = (*Querier)(nil)

--- a/submodules/evm-tx/prune.go
+++ b/submodules/evm-tx/prune.go
@@ -1,0 +1,77 @@
+package tx
+
+import (
+	"context"
+
+	"cosmossdk.io/collections"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func (sub EvmTxSubmodule) prune(ctx context.Context, minHeight int64) error {
+	// clear txhashesBySequenceMap using sequenceByHeightMap
+	var sequence uint64
+	rnHeight := new(collections.Range[int64]).StartInclusive(1).EndInclusive(minHeight)
+	err := sub.sequenceByHeightMap.Walk(ctx, rnHeight, func(key int64, seq uint64) (bool, error) {
+		sequence = seq
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if err = sub.sequenceByHeightMap.Clear(ctx, rnHeight); err != nil {
+		return err
+	}
+
+	rnSeq := new(collections.Range[uint64]).EndInclusive(sequence)
+	if err = sub.txhashesBySequenceMap.Clear(ctx, rnSeq); err != nil {
+		return err
+	}
+
+	// clear txhashesByAccountMap using accountSequenceByHeightMap
+	accountSequenceMap := make(map[string]uint64)
+	rnTriple := collections.NewPrefixUntilTripleRange[int64, sdk.AccAddress, uint64](minHeight)
+	err = sub.accountSequenceByHeightMap.Walk(ctx, rnTriple, func(key collections.Triple[int64, sdk.AccAddress, uint64], value bool) (bool, error) {
+		accountSequenceMap[key.K2().String()] = key.K3()
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if err = sub.accountSequenceByHeightMap.Clear(ctx, rnTriple); err != nil {
+		return err
+	}
+
+	for addr, seq := range accountSequenceMap {
+		acc, _ := sdk.AccAddressFromBech32(addr)
+		rnPair := collections.NewPrefixedPairRange[sdk.AccAddress, uint64](acc).EndInclusive(seq)
+		if err = sub.txhashesByAccountMap.Clear(ctx, rnPair); err != nil {
+			return err
+		}
+	}
+
+	// clear everything else
+	// do not clear sequence and accountSequenceMap as they merely track sequence numbers
+	var txHashes []string
+	rnPair := collections.NewPrefixUntilPairRange[int64, uint64](minHeight)
+	err = sub.txhashesByHeightMap.Walk(ctx, rnPair, func(key collections.Pair[int64, uint64], txHash string) (bool, error) {
+		txHashes = append(txHashes, txHash)
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if err = sub.txhashesByHeightMap.Clear(ctx, rnPair); err != nil {
+		return err
+	}
+
+	for _, txHash := range txHashes {
+		if err := sub.txMap.Remove(ctx, txHash); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/submodules/evm-tx/submodule.go
+++ b/submodules/evm-tx/submodule.go
@@ -16,7 +16,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 
 	"github.com/initia-labs/kvindexer/collection"
-	"github.com/initia-labs/kvindexer/submodules/tx/types"
+	"github.com/initia-labs/kvindexer/submodules/evm-tx/types"
 	kvindexer "github.com/initia-labs/kvindexer/x/kvindexer/types"
 )
 
@@ -31,6 +31,10 @@ type EvmTxSubmodule struct {
 	txhashesByHeightMap   *collections.Map[collections.Pair[int64, uint64], string]
 	txhashesByAccountMap  *collections.Map[collections.Pair[sdk.AccAddress, uint64], string]
 	accountSequenceMap    *collections.Map[sdk.AccAddress, uint64]
+
+	// for pruning
+	sequenceByHeightMap        *collections.Map[int64, uint64]
+	accountSequenceByHeightMap *collections.Map[collections.Triple[int64, sdk.AccAddress, uint64], bool]
 }
 
 func NewTxSubmodule(
@@ -73,15 +77,29 @@ func NewTxSubmodule(
 		return nil, err
 	}
 
+	prefixSequenceByHeight := collection.NewPrefix(types.SubmoduleName, types.SequenceByHeightPrefix)
+	sequenceByHeightMap, err := collection.AddMap(indexerKeeper, prefixSequenceByHeight, "sequence_by_height", collections.Int64Key, collections.Uint64Value)
+	if err != nil {
+		return nil, err
+	}
+
+	prefixAccountSequenceByHeight := collection.NewPrefix(types.SubmoduleName, types.AccountSequenceByHeightPrefix)
+	accountSequenceByHeightMap, err := collection.AddMap(indexerKeeper, prefixAccountSequenceByHeight, "account_sequence_by_height", collections.TripleKeyCodec(collections.Int64Key, sdk.AccAddressKey, collections.Uint64Key), collections.BoolValue)
+	if err != nil {
+		return nil, err
+	}
+
 	return &EvmTxSubmodule{
 		cdc: cdc,
 
-		sequence:              sequence,
-		txMap:                 txMap,
-		txhashesByAccountMap:  txhashesByAccountMap,
-		txhashesBySequenceMap: txhashesBySequenceMap,
-		txhashesByHeightMap:   txhashesByHeightMap,
-		accountSequenceMap:    accountSequenceMap,
+		sequence:                   sequence,
+		txMap:                      txMap,
+		txhashesByAccountMap:       txhashesByAccountMap,
+		txhashesBySequenceMap:      txhashesBySequenceMap,
+		txhashesByHeightMap:        txhashesByHeightMap,
+		accountSequenceMap:         accountSequenceMap,
+		sequenceByHeightMap:        sequenceByHeightMap,
+		accountSequenceByHeightMap: accountSequenceByHeightMap,
 	}, nil
 }
 
@@ -124,5 +142,5 @@ func (sub EvmTxSubmodule) Commit(ctx context.Context, res abci.ResponseCommit, c
 }
 
 func (sub EvmTxSubmodule) Prune(ctx context.Context, minHeight int64) error {
-	return nil
+	return sub.prune(ctx, minHeight)
 }

--- a/submodules/evm-tx/submodule.go
+++ b/submodules/evm-tx/submodule.go
@@ -122,3 +122,7 @@ func (sub EvmTxSubmodule) FinalizeBlock(ctx context.Context, req abci.RequestFin
 func (sub EvmTxSubmodule) Commit(ctx context.Context, res abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
 	return nil
 }
+
+func (sub EvmTxSubmodule) Prune(ctx context.Context, minHeight int64) error {
+	return nil
+}

--- a/submodules/evm-tx/types/keys.go
+++ b/submodules/evm-tx/types/keys.go
@@ -5,15 +5,17 @@ const (
 	SubmoduleName = "evm-tx"
 
 	// Version is the current version of the submodule
-	Version = "v0.1.1"
+	Version = "v0.1.2"
 )
 
 // store prefixes
 const (
-	TxsByAccountPrefix    = 0x10
-	AccountSequencePrefix = 0x20
-	SequencePrefix        = 0xa0
-	TxSequencePrefix      = 0xb0
-	TxByHeightPrefix      = 0xc0
-	TxsPrefix             = 0xf0
+	TxsByAccountPrefix            = 0x10
+	AccountSequencePrefix         = 0x20
+	SequencePrefix                = 0xa0
+	TxSequencePrefix              = 0xb0
+	TxByHeightPrefix              = 0xc0
+	TxsPrefix                     = 0xf0
+	SequenceByHeightPrefix        = 0xd0
+	AccountSequenceByHeightPrefix = 0xe0
 )

--- a/submodules/move-nft/submodule.go
+++ b/submodules/move-nft/submodule.go
@@ -123,3 +123,7 @@ func (sub MoveNftSubmodule) FinalizeBlock(ctx context.Context, req abci.RequestF
 func (sub MoveNftSubmodule) Commit(ctx context.Context, res abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
 	return nil
 }
+
+func (sub MoveNftSubmodule) Prune(ctx context.Context, minHeight int64) error {
+	return nil
+}

--- a/submodules/pair/submodule.go
+++ b/submodules/pair/submodule.go
@@ -99,3 +99,7 @@ func (sub PairSubmodule) FinalizeBlock(ctx context.Context, req abci.RequestFina
 func (sub PairSubmodule) Commit(ctx context.Context, res abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
 	return nil
 }
+
+func (sub PairSubmodule) Prune(ctx context.Context, minHeight int64) error {
+	return nil
+}

--- a/submodules/tx/collect.go
+++ b/submodules/tx/collect.go
@@ -128,7 +128,11 @@ func (sm TxSubmodule) storeAccTxs(ctx context.Context, height int64, addr string
 	if len(txHashes) == 0 {
 		return nil
 	}
-	acc, _ := sdk.AccAddressFromBech32(addr)
+	acc, err := sdk.AccAddressFromBech32(addr)
+	if err != nil {
+		sm.Logger(ctx).Info("failed to convert address", "error", err, "address", addr)
+		return err
+	}
 
 	seq, err := sm.accountSequenceMap.Get(ctx, acc)
 	if err != nil && !cosmoserr.IsOf(err, collections.ErrNotFound) {

--- a/submodules/tx/collect.go
+++ b/submodules/tx/collect.go
@@ -78,11 +78,12 @@ func (sm TxSubmodule) processTxs(ctx context.Context, req abci.RequestFinalizeBl
 
 	// store tx/account pair into txAccMap
 	for addr, txHashes := range accTxMap {
-		err := sm.storeAccTxs(ctx, addr, txHashes)
+		err := sm.storeAccTxs(ctx, req.Height, addr, txHashes)
 		if err != nil {
 			sm.Logger(ctx).Info("failed to store tx/account pair", "error", err, "address", addr)
 		}
 	}
+
 	return sm.storeIndices(ctx, req.Height, txHashes)
 }
 
@@ -123,7 +124,7 @@ func grepAddressesFromTx(txr *sdk.TxResponse) ([]string, error) {
 	return grepped, nil
 }
 
-func (sm TxSubmodule) storeAccTxs(ctx context.Context, addr string, txHashes []string) error {
+func (sm TxSubmodule) storeAccTxs(ctx context.Context, height int64, addr string, txHashes []string) error {
 	if len(txHashes) == 0 {
 		return nil
 	}
@@ -140,15 +141,16 @@ func (sm TxSubmodule) storeAccTxs(ctx context.Context, addr string, txHashes []s
 			sm.Logger(ctx).Info("failed to store tx/account pair", "error", err, "address", addr, "txhash", txHash)
 			continue
 		}
-
 	}
+
 	delta := seq + uint64(len(txHashes)+1)
 	if err = sm.accountSequenceMap.Set(ctx, acc, delta); err != nil {
 		sm.Logger(ctx).Info("failed to store account sequence", "error", err, "address", addr, "delta", delta)
 		return err
 	}
 
-	return err
+	// store (height, account, sequence) for pruning
+	return sm.accountSequenceByHeightMap.Set(ctx, collections.Join3(height, acc, delta), true)
 }
 
 func (sm TxSubmodule) storeIndices(ctx context.Context, height int64, txHashes []string) error {
@@ -170,5 +172,11 @@ func (sm TxSubmodule) storeIndices(ctx context.Context, height int64, txHashes [
 		}
 	}
 
-	return nil
+	// store height -> sequence for pruning
+	seq, err := sm.sequence.Peek(ctx)
+	if err != nil {
+		return err
+	}
+
+	return sm.sequenceByHeightMap.Set(ctx, height, seq)
 }

--- a/submodules/tx/prune.go
+++ b/submodules/tx/prune.go
@@ -1,0 +1,77 @@
+package tx
+
+import (
+	"context"
+
+	"cosmossdk.io/collections"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func (sub TxSubmodule) prune(ctx context.Context, minHeight int64) error {
+	// clear txhashesBySequenceMap using sequenceByHeightMap
+	var sequence uint64
+	rnHeight := new(collections.Range[int64]).StartInclusive(1).EndInclusive(minHeight)
+	err := sub.sequenceByHeightMap.Walk(ctx, rnHeight, func(key int64, seq uint64) (bool, error) {
+		sequence = seq
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if err = sub.sequenceByHeightMap.Clear(ctx, rnHeight); err != nil {
+		return err
+	}
+
+	rnSeq := new(collections.Range[uint64]).EndInclusive(sequence)
+	if err = sub.txhashesBySequenceMap.Clear(ctx, rnSeq); err != nil {
+		return err
+	}
+
+	// clear txhashesByAccountMap using accountSequenceByHeightMap
+	accountSequenceMap := make(map[string]uint64)
+	rnTriple := collections.NewPrefixUntilTripleRange[int64, sdk.AccAddress, uint64](minHeight)
+	err = sub.accountSequenceByHeightMap.Walk(ctx, rnTriple, func(key collections.Triple[int64, sdk.AccAddress, uint64], value bool) (bool, error) {
+		accountSequenceMap[key.K2().String()] = key.K3()
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if err = sub.accountSequenceByHeightMap.Clear(ctx, rnTriple); err != nil {
+		return err
+	}
+
+	for addr, seq := range accountSequenceMap {
+		acc, _ := sdk.AccAddressFromBech32(addr)
+		rnPair := collections.NewPrefixedPairRange[sdk.AccAddress, uint64](acc).EndInclusive(seq)
+		if err = sub.txhashesByAccountMap.Clear(ctx, rnPair); err != nil {
+			return err
+		}
+	}
+
+	// clear everything else
+	// do not clear sequence and accountSequenceMap as they merely track sequence numbers
+	var txHashes []string
+	rnPair := collections.NewPrefixUntilPairRange[int64, uint64](minHeight)
+	err = sub.txhashesByHeightMap.Walk(ctx, rnPair, func(key collections.Pair[int64, uint64], txHash string) (bool, error) {
+		txHashes = append(txHashes, txHash)
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if err = sub.txhashesByHeightMap.Clear(ctx, rnPair); err != nil {
+		return err
+	}
+
+	for _, txHash := range txHashes {
+		if err := sub.txMap.Remove(ctx, txHash); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/submodules/tx/prune.go
+++ b/submodules/tx/prune.go
@@ -12,7 +12,10 @@ func (sub TxSubmodule) prune(ctx context.Context, minHeight int64) error {
 	var sequence uint64
 	rnHeight := new(collections.Range[int64]).StartInclusive(1).EndInclusive(minHeight)
 	err := sub.sequenceByHeightMap.Walk(ctx, rnHeight, func(key int64, seq uint64) (bool, error) {
-		sequence = seq
+		if seq > sequence {
+			sequence = seq
+		}
+
 		return false, nil
 	})
 	if err != nil {
@@ -44,7 +47,11 @@ func (sub TxSubmodule) prune(ctx context.Context, minHeight int64) error {
 	}
 
 	for addr, seq := range accountSequenceMap {
-		acc, _ := sdk.AccAddressFromBech32(addr)
+		acc, err := sdk.AccAddressFromBech32(addr)
+		if err != nil {
+			return err
+		}
+
 		rnPair := collections.NewPrefixedPairRange[sdk.AccAddress, uint64](acc).EndInclusive(seq)
 		if err = sub.txhashesByAccountMap.Clear(ctx, rnPair); err != nil {
 			return err

--- a/submodules/tx/submodule.go
+++ b/submodules/tx/submodule.go
@@ -122,3 +122,7 @@ func (sub TxSubmodule) FinalizeBlock(ctx context.Context, req abci.RequestFinali
 func (sub TxSubmodule) Commit(ctx context.Context, res abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
 	return nil
 }
+
+func (sub TxSubmodule) Prune(ctx context.Context, minHeight int64) error {
+	return nil
+}

--- a/submodules/tx/types/keys.go
+++ b/submodules/tx/types/keys.go
@@ -5,15 +5,17 @@ const (
 	SubmoduleName = "tx"
 
 	// Version is the current version of the submodule
-	Version = "v0.1.1"
+	Version = "v0.1.2"
 )
 
 // store prefixes
 const (
-	TxsByAccountPrefix    = 0x10
-	AccountSequencePrefix = 0x20
-	SequencePrefix        = 0xa0
-	TxSequencePrefix      = 0xb0
-	TxByHeightPrefix      = 0xc0
-	TxsPrefix             = 0xf0
+	TxsByAccountPrefix            = 0x10
+	AccountSequencePrefix         = 0x20
+	SequencePrefix                = 0xa0
+	TxSequencePrefix              = 0xb0
+	TxByHeightPrefix              = 0xc0
+	TxsPrefix                     = 0xf0
+	SequenceByHeightPrefix        = 0xd0
+	AccountSequenceByHeightPrefix = 0xe0
 )

--- a/submodules/wasm-nft/submodule.go
+++ b/submodules/wasm-nft/submodule.go
@@ -123,3 +123,7 @@ func (sm WasmNFTSubmodule) FinalizeBlock(ctx context.Context, req abci.RequestFi
 func (sm WasmNFTSubmodule) Commit(ctx context.Context, res abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
 	return nil
 }
+
+func (sub WasmNFTSubmodule) Prune(ctx context.Context, minHeight int64) error {
+	return nil
+}

--- a/submodules/wasm-pair/submodule.go
+++ b/submodules/wasm-pair/submodule.go
@@ -99,3 +99,7 @@ func (sub PairSubmodule) FinalizeBlock(ctx context.Context, req abci.RequestFina
 func (sub PairSubmodule) Commit(ctx context.Context, res abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
 	return nil
 }
+
+func (sub PairSubmodule) Prune(ctx context.Context, minHeight int64) error {
+	return nil
+}

--- a/x/kvindexer/keeper/handler.go
+++ b/x/kvindexer/keeper/handler.go
@@ -115,14 +115,14 @@ func (k *Keeper) prune(ctx context.Context, height int64) {
 	go func(ctx context.Context, height int64) {
 		defer k.pruningRunning.Store(false)
 
-		minHeight := height - int64(k.config.RetainHeight)
+		minHeight := height - k.config.RetainHeight
 		if minHeight <= 0 || minHeight >= height {
 			return
 		}
 
 		for _, svc := range k.submodules {
 			if err := svc.Prune(ctx, minHeight); err != nil {
-				k.Logger(ctx).Error("failed to prune", "name", svc.Name, "error", err)
+				k.Logger(ctx).Error("failed to prune", "name", svc.Name(), "error", err)
 			}
 		}
 	}(ctx, height)

--- a/x/kvindexer/keeper/keeper.go
+++ b/x/kvindexer/keeper/keeper.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/address"
@@ -38,6 +39,8 @@ type Keeper struct {
 	sealed bool
 
 	submodules map[string]types.Submodule
+
+	pruningRunning *atomic.Bool
 }
 
 // Close closes indexer goleveldb
@@ -60,14 +63,15 @@ func NewKeeper(
 ) *Keeper {
 
 	k := &Keeper{
-		cdc:    cdc,
-		vmType: vmType,
-		db:     db,
-		config: config,
-		schema: nil,
-		ac:     ac,
-		vc:     vc,
-		sealed: false,
+		cdc:            cdc,
+		vmType:         vmType,
+		db:             db,
+		config:         config,
+		schema:         nil,
+		ac:             ac,
+		vc:             vc,
+		sealed:         false,
+		pruningRunning: &atomic.Bool{},
 	}
 
 	k.submodules = make(map[string]types.Submodule)

--- a/x/kvindexer/types/expected_keeper.go
+++ b/x/kvindexer/types/expected_keeper.go
@@ -20,6 +20,7 @@ type Submodule interface {
 	Commit(ctx context.Context, res abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error
 	RegisterQueryHandlerClient(ctx client.Context, mux *runtime.ServeMux) error
 	RegisterQueryServer(s grpc.Server)
+	Prune(ctx context.Context, minHeight int64) error
 
 	Name() string
 	Version() string


### PR DESCRIPTION
- add pruning for block, tx, evm-tx submodules
- add config for indexer.retain-height (0 to disable pruning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added configuration option for indexer data retention.
  - Introduced pruning mechanism for various submodules (block, EVM transactions, NFTs, etc.).
  - Added new methods for pruning in multiple submodules.

- **Improvements**
  - Enhanced indexer configuration to specify height retention.
  - Added support for cleaning up historical data across different modules.

- **Version Updates**
  - Updated version numbers for various submodules.
  - Upgraded Go version to 1.23.3.

- **Technical Changes**
  - Refactored transaction and account sequence tracking.
  - Implemented asynchronous pruning mechanism for indexer data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->